### PR TITLE
Update to in-progress Rustls, webpki, and webpki-roots.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,13 +17,14 @@ appveyor = { repository = "quininer/tokio-rustls" }
 [dependencies]
 futures = "0.1.15"
 tokio-io = "0.1.3"
-rustls = "0.11"
+rustls = { git = "https://github.com/ctz/rustls" }
 tokio-proto = { version = "0.1.1", optional = true }
+webpki = { git = "https://github.com/briansmith/webpki" }
 
 [dev-dependencies]
 tokio-core = "0.1.9"
 clap = "2.26"
-webpki-roots = "0.13"
+webpki-roots = { git = "https://github.com/briansmith/webpki-roots", branch = "webpki-github" }
 
 [target.'cfg(unix)'.dev-dependencies]
 tokio-file-unix = "0.4"

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -3,6 +3,7 @@ extern crate rustls;
 extern crate futures;
 extern crate tokio_io;
 extern crate tokio_core;
+extern crate webpki;
 extern crate webpki_roots;
 extern crate tokio_rustls;
 
@@ -67,6 +68,8 @@ fn main() {
         config.root_store.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
     }
     let arc_config = Arc::new(config);
+
+    let domain = webpki::DNSNameRef::try_from_ascii_str(domain).unwrap();
 
     let socket = TcpStream::connect(&addr, &handle);
 

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -11,7 +11,7 @@ use std::net::ToSocketAddrs;
 use std::io::BufReader;
 use std::fs::File;
 use futures::{ Future, Stream };
-use rustls::{ Certificate, PrivateKey, ServerConfig };
+use rustls::{ Certificate, NoClientAuth, PrivateKey, ServerConfig };
 use rustls::internal::pemfile::{ certs, rsa_private_keys };
 use tokio_io::{ io, AsyncRead };
 use tokio_core::net::TcpListener;
@@ -51,7 +51,7 @@ fn main() {
     let mut core = Core::new().unwrap();
     let handle = core.handle();
 
-    let mut config = ServerConfig::new();
+    let mut config = ServerConfig::new(NoClientAuth::new());
     config.set_single_cert(load_certs(cert_file), load_keys(key_file).remove(0));
     let arc_config = Arc::new(config);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 #[cfg_attr(feature = "tokio-proto", macro_use)] extern crate futures;
 #[macro_use] extern crate tokio_io;
 extern crate rustls;
+extern crate webpki;
 
 pub mod proto;
 
@@ -19,7 +20,7 @@ use rustls::{
 
 /// Extension trait for the `Arc<ClientConfig>` type in the `rustls` crate.
 pub trait ClientConfigExt {
-    fn connect_async<S>(&self, domain: &str, stream: S)
+    fn connect_async<S>(&self, domain: webpki::DNSNameRef, stream: S)
         -> ConnectAsync<S>
         where S: AsyncRead + AsyncWrite;
 }
@@ -42,7 +43,7 @@ pub struct AcceptAsync<S>(MidHandshake<S, ServerSession>);
 
 
 impl ClientConfigExt for Arc<ClientConfig> {
-    fn connect_async<S>(&self, domain: &str, stream: S)
+    fn connect_async<S>(&self, domain: webpki::DNSNameRef, stream: S)
         -> ConnectAsync<S>
         where S: AsyncRead + AsyncWrite
     {


### PR DESCRIPTION
Use the new, less error-prone, API in Rustls.